### PR TITLE
Fix wavesynth program transfer via SPI (m-labs/pdq#20)

### DIFF
--- a/examples/pdq_spi_waveform_writing.py
+++ b/examples/pdq_spi_waveform_writing.py
@@ -1,0 +1,93 @@
+from artiq.experiment import *
+
+class PDQSPITEST(EnvExperiment):
+    """PDQ SPI waveform writing examples"""
+    
+    def build(self):
+        self.setattr_device("core")
+        self.setattr_device("pdq_spi0")
+        self.setattr_device("ttl15")  # scope trigger
+        
+        self.setattr_argument("write_method",NumberValue(0, ndecimals=0, step=1, min=0, max=2))
+                
+        tstep=5000
+        scale=5
+        self.frames=32
+        self.wavesynth_example = [
+                [
+                    {
+                        "trigger": True,
+                        "duration": tstep,
+                        "channel_data": [
+                            {"bias":     {"amplitude": [0, i/tstep/scale]}},
+                        ],
+                    },
+                    {
+                        "duration": tstep,
+                        "channel_data": [
+                            {"bias": {"amplitude": [i/scale]}},
+                        ],
+                    },
+                    {
+                        "duration": tstep,
+                        "channel_data": [
+                            {"bias": {"amplitude": [i/scale, -i/tstep/scale]}},
+                        ],
+                    },
+                ]
+                for i in range(self.frames)
+        ]
+        self.wavesynth_example2 = [
+                [
+                    {
+                        "trigger": True,
+                        "duration": tstep,
+                        "channel_data": [
+                            {"dds":     {"amplitude": [scale, 0,0,0],
+                                         "phase": [0,i*1e-5]}},
+                        ],
+                    },
+                ]
+                for i in range(self.frames)
+        ]
+
+   
+    @kernel
+    def init(self):
+        self.core.reset()
+        self.pdq_spi0.setup_bus(write_div=50, read_div=50)
+        self.pdq_spi0.set_config(reset=1)
+        delay(10*us)
+
+    @kernel
+    def trigger(self):
+        """Switches frames via SPI and triggers each time."""
+        self.core.break_realtime()
+        for frame in range(self.frames):
+            self.pdq_spi0.set_frame(frame)
+            self.ttl15.pulse(10*us)  # scope trigger
+            self.pdq_spi0.set_config(clk2x=0, trigger=1, enable=1, aux_miso=1)
+            self.pdq_spi0.set_config(clk2x=0, trigger=0, enable=1, aux_miso=1)
+            delay(0.25*s)
+            
+ 
+    def prepare(self):
+        self.chan_list, self.chan_data_list = self.pdq_spi0.program_host(self.wavesynth_example)
+        self.pdq_spi0.program_host(self.wavesynth_example2)
+    
+    @kernel
+    def write_waveform(self, method=0):
+        """Writes the wavesynth data to the PDQs via SPI using one of three different methods"""
+        if method == 0:  # use latest output of meth:`program_host`
+            self.pdq_spi0.program_kernel()
+        if method == 1:  # use manually stored output of meth:`program_host`
+            self.pdq_spi0.program_kernel(self.chan_list, self.chan_data_list)
+        if method == 2:  # convert wavesynth data via an RPC (not particularly efficient)
+            delay(0.5*s)  # some slack for the RPC
+            self.pdq_spi0.program(self.wavesynth_example)
+        
+    @kernel
+    def run(self):
+        self.init()
+        self.write_waveform(self.write_method)  
+        self.trigger()

--- a/pdq/artiq/spi.py
+++ b/pdq/artiq/spi.py
@@ -1,5 +1,6 @@
 from artiq.language.core import kernel, delay_mu
 from artiq.coredevice import spi
+from artiq.language.types import TList, TBytes
 
 from ..host.protocol import PDQBase, PDQ_CMD
 
@@ -37,6 +38,11 @@ class PDQ(PDQBase):
         self.chip_select = chip_select
         PDQBase.__init__(self, **kwargs)
 
+        # lists to store the output of :meth:`program_host`, for writing to the
+        # hardware using :meth:`program_kernel`.
+        self.channel_list = []
+        self.channel_data_list = []
+
     @kernel
     def setup_bus(self, write_div=24, read_div=64):
         """Configure the SPI bus and the SPI transaction parameters
@@ -64,6 +70,7 @@ class PDQ(PDQBase):
         :param data: Register data (8 bit).
         :param board: Board to access, ``0xf`` to write to all boards.
         """
+        self.bus.set_xfer(self.chip_select, 16, 0)
         self.bus.write((PDQ_CMD(board, 0, adr, 1) << 24) | (data << 16))
         delay_mu(self.bus.ref_period_mu)  # get to 20ns min cs high
 
@@ -85,12 +92,12 @@ class PDQ(PDQBase):
         return int(self.bus.input_async() & 0xff)  # FIXME: m-labs/artiq#713
 
     @kernel
-    def write_mem(self, mem, adr, data, board=0xf):  # FIXME: m-labs/artiq#714
+    def write_mem(self, mem, adr, data, board=0xf):
         """Write to DAC channel waveform data memory.
 
         :param mem: DAC channel memory to access (0 to 2).
         :param adr: Start address.
-        :param data: Memory data. List of 16 bit integers.
+        :param data: (bytes) Memory data.
         :param board: Board to access (0-15) with ``0xf = 15`` being broadcast
             to all boards.
         """
@@ -98,9 +105,9 @@ class PDQ(PDQBase):
         self.bus.write((PDQ_CMD(board, 1, mem, 1) << 24) |
                        ((adr & 0x00ff) << 16) | (adr & 0xff00))
         delay_mu(-self.bus.write_period_mu-3*self.bus.ref_period_mu)
-        self.bus.set_xfer(self.chip_select, 16, 0)
-        for i in data:
-            self.bus.write(i << 16)
+        self.bus.set_xfer(self.chip_select, 8, 0)
+        for i in range(len(data)):
+            self.bus.write(data[i] << 24)
             delay_mu(-self.bus.write_period_mu)
         delay_mu(self.bus.write_period_mu + self.bus.ref_period_mu)
         # get to 20ns min cs high
@@ -111,7 +118,7 @@ class PDQ(PDQBase):
 
         :param mem: DAC channel memory to access (0 to 2).
         :param adr: Start address.
-        :param data: Memory data. List of 16 bit integers.
+        :param data: (bytearray) Memory data.
         :param board: Board to access (0-15) with ``0xf = 15`` being broadcast
             to all boards.
         """
@@ -122,7 +129,7 @@ class PDQ(PDQBase):
         self.bus.write((PDQ_CMD(board, 1, mem, 0) << 24) |
                        ((adr & 0x00ff) << 16) | (adr & 0xff00))
         delay_mu(-self.bus.write_period_mu-3*self.bus.ref_period_mu)
-        self.bus.set_xfer(self.chip_select, 0, 16)
+        self.bus.set_xfer(self.chip_select, 0, 8)
         for i in range(n):
             self.bus.write(0)
             delay_mu(-self.bus.read_period_mu)
@@ -130,9 +137,98 @@ class PDQ(PDQBase):
                 delay_mu(-3*self.bus.ref_period_mu)
                 self.bus.read_async()
             if i > buffer:
-                data[i - 1 - buffer] = self.bus.input_async() & 0xffff
+                data[i - 1 - buffer] = self.bus.input_async() & 0xff
         delay_mu(self.bus.read_period_mu)
-        self.bus.set_xfer(self.chip_select, 16, 0)
         self.bus.read_async()
-        for i in range(max(0, n - buffer - 1), n):
-            data[i] = self.bus.input_async() & 0xffff
+        for i in range(max(0, n - 1 - buffer), n):
+            data[i] = self.bus.input_async() & 0xff
+
+    def program_host(self, program, channels=None):
+        """Serialize a wavesynth program. The result is stored in member
+        variables and returned for manual handling. Use :meth:`program_kernel`
+        to write it to memory.
+
+        The :class:`Channel` targeted are cleared and each frame in the
+        wavesynth program is appended to a fresh set of :class:`Segment`
+        of the channels. All segments are allocated, the frame address table
+        is generated and the channels are serialized.
+
+        Short single-cycle lines are prepended and appended to each frame to
+        allow proper write interlocking and to assure that the memory reader
+        can be reliably parked in the frame address table.
+        The first line of each frame is mandatorily triggered.
+
+        :param program: (list) Wavesynth program.
+        :param channels: (list[int]) Channel indices to use. If unspecified, all
+                channels are used.
+
+        :return (list[int]), (list[bytes]): List of channels and list of channel
+        data to be written to the hardware using :meth:`program_kernel`
+        """
+        if channels is None:
+            channels = range(self.num_channels)
+        chs = [self.channels[i] for i in channels]
+        for channel in chs:
+            channel.clear()
+        for frame in program:
+            segments = [c.new_segment() for c in chs]
+            self.program_segments(segments, frame)
+            # append an empty line to stall the memory reader before jumping
+            # through the frame table (`wait` does not prevent reading
+            # the next line)
+            for segment in segments:
+                segment.line(typ=3, data=b"", trigger=True, duration=1, aux=1,
+                             jump=True)
+        self.channel_list = []
+        self.channel_data_list = []
+        for channel, ch in zip(channels, chs):
+            self.channel_list.append(channel)
+            self.channel_data_list.append(ch.serialize())
+        return self.channel_list, self.channel_data_list
+
+    def program_rpc(self, program, channels=None) -> TList(TBytes):
+        """
+        Wrapper for :meth:`program_host` with only one return value for use in RPCs
+        :param program: (list) Wavesynth program.
+        :param channels: (list[int]) Channel indices to use. If unspecified, all
+                         channels are used.
+        """
+        _, channel_data_list = self.program_host(program, channels)
+        return channel_data_list
+
+    @kernel
+    def program_kernel(self, channel_list=[-1], channel_data_list=[bytes([0])]):
+        """
+        Write the output of :meth:`program_host` via SPI.
+
+        :param channel_list: (list[int]) (optional) List of channels as returned by
+                             :meth:`program_host`. Set to [-1] to use values stored
+                             from the last invocation of :meth:`program_host`.
+        :param channel_data_list: (list[bytes]) (optional) List of corresponding
+                                  data as returned by :meth:`program_host`
+        """
+        if channel_list == [-1]:
+            channel_list = list(self.channel_list)
+            channel_data_list = list(self.channel_data_list)
+        assert len(channel_data_list) >= len(channel_list)
+        for i in range(len(channel_list)):
+            board = channel_list[i] // self.num_dacs
+            mem = channel_list[i] % self.num_dacs
+            self.write_mem(mem=mem, adr=0, data=channel_data_list[i],
+                           board=board)
+
+    @kernel
+    def program(self, program, channels=[-1]):
+        """
+        Replaces the inherited :meth:`program` method from :class:`PDQBase`,
+        which doesn't work via SPI due to the mixture of host and kernel
+        functions. Because of the RPC, this is not the most efficient solution.
+        :param program (list): Wavesynth program.
+        :param channels (list[int]): Channel indices to use. By default, all
+                                     channels are used.
+        """
+        if channels == [-1]:
+            channels = list(range(self.num_channels))
+
+        channel_data_list = self.program_rpc(program, channels)
+        self.program_kernel(channels, channel_data_list)


### PR DESCRIPTION
This is my suggestion for fixing the behavior of `PDQ.program()` for the SPI version as discussed in m-labs/pdq#20.

The method is split between a host (`program_host()`) and a kernel (`program_kernel()`) method. The output of the former is a list of channels and a list of bytes objects, which are both stored in class variables and returned for manual handling. The latter writes the latest output by default for convenience, but can also be passed other previously stored data for flexibility.

The `program()` method of the base class is overridden by a kernel method which calls `program_host()` as an RPC.

The `write_mem` method now takes bytes objects instead of list[int16], and `read_mem` manipulates a bytearray object rather than a list[int16].

Finally, I've adjusted the example in `examples/pdq_spi.py` accordingly and added an example for the different options to write wavesynth programs, `examples/pdq_spi_waveform_writing.py`